### PR TITLE
Plack::Handler::Standalone::Prefork::Server::Starter isn't included anymore

### DIFF
--- a/t/00base.t
+++ b/t/00base.t
@@ -55,7 +55,6 @@ sub doit {
 
 if ($start_server) {
     doit('Starlet');
-    doit('Standalone::Prefork::Server::Starter');
 } else {
     warn "could not find `start_server' next to $^X nor from \$PATH, skipping tests";
 }


### PR DESCRIPTION
So we should stop testing it. This is causing install failures on a fresh install attempt.
