### PR TITLE
support unix domain socket 

### DIFF
--- a/lib/Starlet/Server.pm
+++ b/lib/Starlet/Server.pm
@@ -76,8 +76,11 @@ sub setup_listener {
         ReuseAddr => 1,
     ) or die "failed to listen to port $self->{port}:$!";
 
+    my $family = Socket::sockaddr_family(getsockname($self->{listen_sock}));
+    $self->{_listen_unix} = $family == AF_UNIX;
+
     # set defer accept
-    if ($^O eq 'linux') {
+    if ($^O eq 'linux' && !$self->{_listen_unix}) {
         setsockopt($self->{listen_sock}, IPPROTO_TCP, 9, 1)
             and $self->{_using_defer_accept} = 1;
     }
@@ -107,10 +110,13 @@ sub accept_loop {
             $self->{_is_deferred_accept} = $self->{_using_defer_accept};
             $conn->blocking(0)
                 or die "failed to set socket to nonblocking mode:$!";
-            $conn->setsockopt(IPPROTO_TCP, TCP_NODELAY, 1)
-                or die "setsockopt(TCP_NODELAY) failed:$!";
-            my ($peerport,$peerhost) = unpack_sockaddr_in $peer;
-            my $peeraddr = inet_ntoa($peerhost);
+            my ($peerport,$peerhost, $peeraddr) = (0, undef, undef);
+            if ( !$self->{_listen_unix} ) {
+                $conn->setsockopt(IPPROTO_TCP, TCP_NODELAY, 1)
+                    or die "setsockopt(TCP_NODELAY) failed:$!";
+                ($peerport,$peerhost) = unpack_sockaddr_in $peer;
+                $peeraddr = inet_ntoa($peerhost);
+            }
             my $req_count = 0;
             my $pipelined_buf = '';
 
@@ -118,8 +124,8 @@ sub accept_loop {
                 ++$req_count;
                 ++$proc_req_count;
                 my $env = {
-                    SERVER_PORT => $self->{port},
-                    SERVER_NAME => $self->{host},
+                    SERVER_PORT => $self->{port} || 0,
+                    SERVER_NAME => $self->{host} || 0,
                     SCRIPT_NAME => '',
                     REMOTE_ADDR => $peeraddr,
                     REMOTE_PORT => $peerport,

--- a/t/10unix_domain_socket.t
+++ b/t/10unix_domain_socket.t
@@ -1,0 +1,51 @@
+use strict;
+use Test::More;
+use Plack::Loader;
+use File::Temp;
+use IO::Socket::UNIX;
+use Socket;
+
+my ($fh, $filename) = File::Temp::tempfile(UNLINK=>0);
+close($fh);
+unlink($filename);
+
+my $sock = IO::Socket::UNIX->new(
+    Listen => Socket::SOMAXCONN(),
+    Local  => $filename,
+) or die "failed to listen to socket $filename:$!";
+$ENV{SERVER_STARTER_PORT} = $filename.'='.$sock->fileno;
+
+my $pid = fork;
+if ( $pid == 0 ) {
+    # server
+    my $loader = Plack::Loader->load(
+        'Starlet',
+        max_workers => 5,
+    );
+    $loader->run(sub{
+        my $env = shift;
+        my $remote = $env->{REMOTE_ADDR};
+        $remote = 'UNIX' if ! defined $remote;
+        [200, ['Content-Type'=>'text/html'], ["HELLO $remote"]];
+    });
+    exit;
+}
+
+sleep 1;
+
+my $client = IO::Socket::UNIX->new(
+    Peer  => $filename,
+    timeout => 3,
+) or die "failed to listen to socket $filename:$!";
+
+$client->syswrite("GET / HTTP/1.0\015\012\015\012");
+$client->sysread(my $buf, 1024);
+like $buf, qr/Starlet/;
+like $buf, qr/HELLO UNIX/;
+
+done_testing();
+
+kill 'TERM',$pid;
+waitpid($pid,0);
+unlink($filename);
+


### PR DESCRIPTION
if unix domain socket comes from $ENV{SERVER_STARTER_PORT}, Starlet die with 

```
setsockopt(TCP_NODELAY) failed:Operation not supported on socket Starlet/Server.pm line 110.
```

This p-r checks socket family before listen it.
