### PR TITLE
Don't warn when we get invalid request lines

### DIFF
--- a/lib/Starlet/Server.pm
+++ b/lib/Starlet/Server.pm
@@ -408,7 +408,7 @@ sub _handle_response {
 
     # try to set content-length when keepalive can be used, or disable it
     my $use_chunked;
-    if ( $protocol eq 'HTTP/1.0' ) {
+    if ( ! defined $protocol || $protocol eq 'HTTP/1.0' ) {
         if ($$use_keepalive_r) {
             if (defined $send_headers{'content-length'}
                 || defined $send_headers{'transfer-encoding'}) {

--- a/t/12bad_request_line.t
+++ b/t/12bad_request_line.t
@@ -1,0 +1,33 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::TCP qw(test_tcp);
+use IO::Socket::INET;
+use Plack::Loader;
+
+test_tcp(
+    client => sub {
+        my $port = shift;
+        my $sock = IO::Socket::INET->new(
+            PeerAddr => "localhost:$port",
+            Proto => 'tcp',
+        );
+        my $req = "GET /bad request header/ HTTP/1.0\015\012\015\012";
+        $sock->syswrite($req, length $req);
+        $sock->sysread(my $buf, 1024);
+        like $buf, qr/\b400\b/;
+        note $buf;
+    },
+    server => sub {
+        my $port = shift;
+        local $SIG{__WARN__} = sub {
+            ok 0, "No warnings";
+            diag @_;
+        };
+        my $loader = Plack::Loader->load('Starlet', port => $port);
+        $loader->run(sub { [200, ['Content-Type' => 'text/plain'], ['OK']] });
+        exit;
+    },
+);
+
+done_testing;


### PR DESCRIPTION
When I send an invalid request to Starlet, I get following warnings. If someone sends such requests many times, my log file will be filled with this message.

```
% carton exec -- local/bin/plackup -Ilib -s Starlet -e 'sub { [200, [], ["OK"]] }'
Plack::Handler::Starlet: Accepting connections at http://0:5000/
Use of uninitialized value $protocol in string eq at lib/Starlet/Server.pm line 411.
Use of uninitialized value $protocol in string eq at lib/Starlet/Server.pm line 428.
```

```
% telnet localhost 5000
Connected to localhost.
Escape character is '^]'.
GET /invalid request line/ HTTP/1.0

HTTP/1.1 400 Bad Request
Date: Wed, 31 Dec 2014 04:08:54 GMT
Server: Plack::Handler::Starlet
Content-Type: text/plain

Bad RequestConnection closed by foreign host.
```

My patch stops these messages and returns `Connection: closed` header to disconnect the keep-alive connection.