### PR TITLE
fix failing graceful shutdown while accepting

### DIFF
--- a/lib/Starlet/Server.pm
+++ b/lib/Starlet/Server.pm
@@ -125,14 +125,10 @@ sub accept_loop {
     my($self, $app, $max_reqs_per_child) = @_;
     my $proc_req_count = 0;
 
-    $self->{can_exit} = 1;
     my $is_keepalive = 0;
     local $SIG{TERM} = sub {
-        exit 0 if $self->{can_exit};
         $self->{term_received}++;
-        exit 0
-            if ($is_keepalive && $self->{can_exit}) || $self->{term_received} > 1;
-        # warn "server termination delayed while handling current HTTP request";
+        exit 0 if $self->{term_received} > 1;
     };
 
     local $SIG{PIPE} = 'IGNORE';
@@ -207,6 +203,9 @@ sub _get_acceptor {
                 if (my ($conn, $peer) = $listen->{sock}->accept) {
                     return ($conn, $peer, $listen);
                 }
+                elsif ($! == EINTR) {
+                    exit 0 if $self->{term_received};
+                }
             }
         };
     }
@@ -228,10 +227,21 @@ sub _get_acceptor {
         return sub {
             while (1) {
                 while (! flock($lock_fh, LOCK_EX)) {
-                    next if $! == EINTR;
+                    if ($! == EINTR) {
+                        exit 0 if $self->{term_received};
+                        next;
+                    }
                     die "failed to lock file:@{[$self->{lock_path}]}:$!";
                 }
                 my $nfound = select(my $rout = $rin, undef, undef, undef);
+                if ($nfound == -1) { # trap err
+                    if ($! == EINTR) {
+                        flock($lock_fh, LOCK_UN);
+                        exit 0 if $self->{term_received};
+                        next;
+                    }
+                    die "failed to select file:@{[$self->{lock_path}]}:$!";
+                }
                 for (my $i = 0; $nfound > 0; ++$i) {
                     my $fd = $fds[$i];
                     next unless vec($rout, $fd, 1);
@@ -240,6 +250,9 @@ sub _get_acceptor {
                     if (my ($conn, $peer) = $listen->{sock}->accept) {
                         flock($lock_fh, LOCK_UN);
                         return ($conn, $peer, $listen);
+                    }
+                    elsif ($! == EINTR) {
+                        exit 0 if $self->{term_received};
                     }
                 }
                 flock($lock_fh, LOCK_UN);
@@ -256,7 +269,6 @@ sub handle_connection {
     my $pipelined_buf='';
     my $res = $bad_response;
     
-    local $self->{can_exit} = (defined $prebuf) ? 0 : 1;
     while (1) {
         my $rlen;
         if ( $rlen = length $prebuf ) {
@@ -269,7 +281,6 @@ sub handle_connection {
                 $is_keepalive ? $self->{keepalive_timeout} : $self->{timeout},
             ) or return;
         }
-        $self->{can_exit} = 0;
         my $reqlen = parse_http_request($buf, $env);
         if ($reqlen >= 0) {
             # handle request


### PR DESCRIPTION
StarletをServer::Starterを一緒に使っているのですが、
plackを再起動する際、前段でreverse-proxyとして動いているnginxがまれに503 BAD GATEWAYをレポートするという現象に遭遇し困っています。

`accept`してから`$self->{can_exit} = 0`を実行するまでの間にSIGTERMを受け取ると、
コネクションが確立しているのにも関わらず`exit 0`してしまう場合があるのではと予想しています。
シグナルハンドラ内で`exit`する方法ではこの隙間をどうしてもなくすことができないので、
代わりにシステムコール呼び出し後にSIGTERMが送られてきたかチェックするようにしてみました。
ご確認をお願いします。

-----

以下はAWSのc4.largeインスタンスを使って再現実験をした結果です。
20並列100000リクエストの負荷をかけた状態で、一秒毎にplackの再起動を行います。

``` bash
# それぞれのコマンドを別ウインドウで実行
$ start_server --port 5000 --pid app.pid -- plackup -s Starlet --max-workers 20 app.psgi > /dev/null 2>&1
$ while true; do kill -HUP `cat app.pid`; sleep 1; done
$ ab -c 20 -n 100000 -r http://localhost:5000/
```

Starlet 0.25 で実行した場合のapache benchの出力です。
Failed requestsが135件発生してしまいました。

```
This is ApacheBench, Version 2.3 <$Revision: 655654 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 10000 requests
Completed 20000 requests
Completed 30000 requests
Completed 40000 requests
Completed 50000 requests
Completed 60000 requests
Completed 70000 requests
Completed 80000 requests
Completed 90000 requests
Completed 100000 requests
Finished 100000 requests


Server Software:        Plack::Handler::Starlet
Server Hostname:        localhost
Server Port:            5000

Document Path:          /
Document Length:        11 bytes

Concurrency Level:      20
Time taken for tests:   22.619 seconds
Complete requests:      100000
Failed requests:        135
   (Connect: 0, Receive: 45, Length: 45, Exceptions: 45)
Write errors:           0
Total transferred:      14495505 bytes
HTML transferred:       1099659 bytes
Requests per second:    4421.02 [#/sec] (mean)
Time per request:       4.524 [ms] (mean)
Time per request:       0.226 [ms] (mean, across all concurrent requests)
Transfer rate:          625.83 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    1   1.4      1      26
Processing:     0    3   2.0      3      81
Waiting:        0    3   2.0      3      80
Total:          1    5   2.2      4      81

Percentage of the requests served within a certain time (ms)
  50%      4
  66%      5
  75%      5
  80%      6
  90%      7
  95%      8
  98%     10
  99%     12
 100%     81 (longest request)
```

パッチ適用後の結果です。
Failed requestsが0件になります。

```
This is ApacheBench, Version 2.3 <$Revision: 655654 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking localhost (be patient)
Completed 10000 requests
Completed 20000 requests
Completed 30000 requests
Completed 40000 requests
Completed 50000 requests
Completed 60000 requests
Completed 70000 requests
Completed 80000 requests
Completed 90000 requests
Completed 100000 requests
Finished 100000 requests


Server Software:        Plack::Handler::Starlet
Server Hostname:        localhost
Server Port:            5000

Document Path:          /
Document Length:        11 bytes

Concurrency Level:      20
Time taken for tests:   22.405 seconds
Complete requests:      100000
Failed requests:        0
Write errors:           0
Total transferred:      14500725 bytes
HTML transferred:       1100055 bytes
Requests per second:    4463.36 [#/sec] (mean)
Time per request:       4.481 [ms] (mean)
Time per request:       0.224 [ms] (mean, across all concurrent requests)
Transfer rate:          632.05 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    1   1.4      1      29
Processing:     0    3   1.9      3     147
Waiting:        0    3   1.9      3     147
Total:          1    4   2.2      4     149

Percentage of the requests served within a certain time (ms)
  50%      4
  66%      5
  75%      5
  80%      6
  90%      6
  95%      8
  98%      9
  99%     11
 100%    149 (longest request)
```

app.psgiの中身はHello Worldを返すだけのシンプルなplackアプリです。

``` perl
my $app = sub {
    my $env = shift;
    return [
        200,
        [ 'Content-Type' => 'text/plain' ],
        [ "Hello World" ],
	];
};
```
