### PR TITLE
Fix Expect header handling

### DIFF
--- a/lib/Starlet/Server.pm
+++ b/lib/Starlet/Server.pm
@@ -288,6 +288,17 @@ sub handle_connection {
             }
             $buf = substr $buf, $reqlen;
             my $chunked = do { no warnings; lc delete $env->{HTTP_TRANSFER_ENCODING} eq 'chunked' };
+
+            if ( $env->{HTTP_EXPECT} ) {
+                if ( lc $env->{HTTP_EXPECT} eq '100-continue' ) {
+                    $self->write_all($conn, "HTTP/1.1 100 Continue\015\012\015\012")
+                        or return;
+                } else {
+                    $res = [417,[ 'Content-Type' => 'text/plain', 'Connection' => 'close' ], [ 'Expectation Failed' ] ];
+                    last;
+                }
+            }
+
             if (my $cl = $env->{CONTENT_LENGTH}) {
                 my $buffer = Plack::TempBuffer->new($cl);
                 while ($cl > 0) {
@@ -343,16 +354,6 @@ sub handle_connection {
                     $use_keepalive = 1; #force keepalive
                 } # else clear buffer
                 $env->{'psgi.input'} = $null_io;
-            }
-
-            if ( $env->{HTTP_EXPECT} ) {
-                if ( $env->{HTTP_EXPECT} eq '100-continue' ) {
-                    $self->write_all($conn, "HTTP/1.1 100 Continue\015\012\015\012")
-                        or return;
-                } else {
-                    $res = [417,[ 'Content-Type' => 'text/plain', 'Connection' => 'close' ], [ 'Expectation Failed' ] ];
-                    last;
-                }
             }
 
             $res = Plack::Util::run_app $app, $env;

--- a/t/13expect.t
+++ b/t/13expect.t
@@ -1,0 +1,48 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::TCP;
+use LWP::UserAgent;
+use Plack::Loader;
+
+test_tcp(
+    client => sub {
+        my $port = shift;
+        sleep 1;
+        my $ua  = LWP::UserAgent->new;
+        my $res = $ua->post(
+            "http://localhost:$port/",
+            { blah => 1 },
+            Expect => '100-continue'
+        );
+        ok( $res->is_success );
+        is( $res->content, 'HELLO', 'Expect header in standard case works' );
+
+
+        $res = $ua->post(
+            "http://localhost:$port/",
+            { blah => 1 },
+            Expect => '100-Continue'
+        );
+        ok( $res->is_success );
+        is( $res->content, 'HELLO', 'Expect header is case insensitive' );
+    },
+    server => sub {
+        my $port   = shift;
+        my $loader = Plack::Loader->load(
+            'Starlet',
+            port        => $port,
+            max_workers => 5,
+        );
+        $loader->run(
+            sub {
+                my $env = shift;
+                [ 200, [], ['HELLO'] ];
+            }
+        );
+        exit;
+    },
+);
+
+done_testing;
+


### PR DESCRIPTION
Previously the Expect header would be ignored as an earlier read would
time out waiting for the content. "HTTP/1.1 100 Continue" needs to be
sent before the content is read.

Also, this commit makes the comparison for the header case insensitive.
From RFC 2616:

http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.20

"Comparison of expectation values is case-insensitive for unquoted
tokens (including the 100-continue token), and is case-sensitive for
quoted-string expectation-extensions."

From RFC 7231:

http://tools.ietf.org/html/rfc7231#section-5.1.1

"The Expect field-value is case-insensitive."
