### PR TITLE
fix: do not exit in accept_loop

### DIFF
--- a/lib/Plack/Handler/Starlet.pm
+++ b/lib/Plack/Handler/Starlet.pm
@@ -9,7 +9,7 @@ use base qw(Starlet::Server);
 
 sub new {
     my ($klass, %args) = @_;
-    
+
     # setup before instantiation
     if (defined $ENV{SERVER_STARTER_PORT}) {
         $args{listens} = [];
@@ -40,12 +40,18 @@ sub new {
         $max_workers = delete $args{$_}
             if defined $args{$_};
     }
-    
+
+    my $hook_module = delete $args{hook_module};
+    if ($hook_module) {
+        my $child_finish_hook = delete $args{child_finish_hook};
+        $args{child_finish} = eval { $hook_module->can($child_finish_hook) };
+    }
+
     # instantiate and set the variables
     my $self = $klass->SUPER::new(%args);
     $self->{is_multiprocess} = 1;
     $self->{max_workers} = $max_workers;
-    
+
     $self;
 }
 

--- a/lib/Plack/Handler/Starlet.pm
+++ b/lib/Plack/Handler/Starlet.pm
@@ -43,7 +43,7 @@ sub new {
 
     if ($args{child_exit}) {
         $args{child_exit} = eval $args{child_exit} unless ref($args{child_exit});
-        delete $args{child_exit} if ref($args{child_exit}) ne 'CODE';
+        die "child_exit is defined but not a code block" if ref($args{child_exit}) ne 'CODE';
     }
 
     # instantiate and set the variables

--- a/lib/Plack/Handler/Starlet.pm
+++ b/lib/Plack/Handler/Starlet.pm
@@ -41,10 +41,9 @@ sub new {
             if defined $args{$_};
     }
 
-    my $hook_module = delete $args{hook_module};
-    if ($hook_module) {
-        my $child_finish_hook = delete $args{child_finish_hook};
-        $args{child_finish} = eval { $hook_module->can($child_finish_hook) };
+    if ($args{child_exit}) {
+        $args{child_exit} = eval $args{child_exit} unless ref($args{child_exit});
+        delete $args{child_exit} if ref($args{child_exit}) ne 'CODE';
     }
 
     # instantiate and set the variables

--- a/lib/Starlet.pm
+++ b/lib/Starlet.pm
@@ -63,6 +63,14 @@ if set, randomizes the number of requests handled by a single worker process bet
 
 if set, worker processes will not be spawned more than once than every given seconds.  Also, when SIGHUP is being received, no more than one worker processes will be collected every given seconds.  This feature is useful for doing a "slow-restart".  See http://blog.kazuhooku.com/2011/04/web-serverstarter-parallelprefork.html for more information. (default: none)
 
+=head2 --hook-module=s
+
+the module where the hook subroutine locates. Note that this option should be used along with C<--child-finish-hook>.
+
+=head2 --child-finish-hook=s
+
+the subroutine name of child-finish hook in the hook-module. This hook will be called right before a child process exits. Note that C<--hook-module> is required for this option.
+
 =head1 NOTES
 
 L<Starlet> is designed and implemented to be simple, secure and fast, especially for running as an HTTP application server running behind a reverse proxy.  It only depends on a minimal number of well-designed (and well-focused) modules.

--- a/lib/Starlet.pm
+++ b/lib/Starlet.pm
@@ -63,13 +63,9 @@ if set, randomizes the number of requests handled by a single worker process bet
 
 if set, worker processes will not be spawned more than once than every given seconds.  Also, when SIGHUP is being received, no more than one worker processes will be collected every given seconds.  This feature is useful for doing a "slow-restart".  See http://blog.kazuhooku.com/2011/04/web-serverstarter-parallelprefork.html for more information. (default: none)
 
-=head2 --hook-module=s
+=head2 --child-exit=s
 
-the module where the hook subroutine locates. Note that this option should be used along with C<--child-finish-hook>.
-
-=head2 --child-finish-hook=s
-
-the subroutine name of child-finish hook in the hook-module. This hook will be called right before a child process exits. Note that C<--hook-module> is required for this option.
+the subroutine code to be executed right before a child process exits. e.g. C<--child-exit='sub { POSIX::_exit(0) }'>. (default: none)
 
 =head1 NOTES
 

--- a/lib/Starlet/Server.pm
+++ b/lib/Starlet/Server.pm
@@ -50,7 +50,7 @@ sub new {
                 ? $args{err_respawn_interval} : undef,
         ),
         is_multiprocess      => Plack::Util::FALSE,
-        child_finish         => $args{child_finish} || sub {},
+        child_exit           => $args{child_exit} || sub {},
         _using_defer_accept  => undef,
     }, $class;
 
@@ -137,7 +137,7 @@ sub accept_loop {
     while (! defined $max_reqs_per_child || $proc_req_count < $max_reqs_per_child) {
         # accept (or exit on SIGTERM)
         if ($self->{term_received}) {
-            $self->{child_finish}->($self, $app);
+            $self->{child_exit}->($self, $app);
             exit 0;
         }
         my ($conn, $peer, $listen) = $acceptor->();

--- a/t/14child_finish_hook.t
+++ b/t/14child_finish_hook.t
@@ -2,59 +2,29 @@ use strict;
 use warnings;
 
 use Test::More;
-use Plack::Loader;
 use Plack::Runner;
 
-$SIG{CONT} = sub { pass('child_finish has been executed.') };
+$SIG{CONT} = sub { pass('child_exit has been executed.') };
 
-subtest 'child_finish' => sub {
-    plan tests => 1;
-    my $main_pid = $$;
-    my $pid = fork;
-    if ( $pid == 0 ) {
-        my $loader = Plack::Loader->load(
-            'Starlet',
-            max_workers => 1,
-            child_finish  => sub { kill 'CONT', $main_pid },
-        );
-        $loader->run(sub{
-            my $env = shift;
-            [200, ['Content-Type'=>'text/html'], ["HELLO"]];
-        });
-        exit 0;
-    }
+plan tests => 1;
+our $main_pid = $$;
+my $pid = fork;
+if ( $pid == 0 ) {
+    my $runner = Plack::Runner->new;
+    $runner->parse_options(
+        qw(--server Starlet --max-workers 1 --child-exit),
+        "sub { kill 'CONT', $main_pid }",
+    );
+    $runner->run(sub{
+        my $env = shift;
+        [200, ['Content-Type'=>'text/html'], ["HELLO"]];
+    });
+    exit 0;
+}
 
-    sleep 1;
+sleep 1;
 
-    kill 'TERM', $pid;
-    waitpid($pid, 0);
-};
-
-subtest 'hook_module' => sub {
-    plan tests => 1;
-    our $main_pid = $$;
-    my $pid = fork;
-    if ( $pid == 0 ) {
-        {
-            package ChildFinishHook;
-            sub child_finish_hook { kill 'CONT', $main_pid }
-        }
-        my $runner = Plack::Runner->new;
-        $runner->parse_options(
-            qw(--server Starlet --max-workers 1
-               --hook-module ChildFinishHook --child-finish-hook child_finish_hook)
-        );
-        $runner->run(sub{
-            my $env = shift;
-            [200, ['Content-Type'=>'text/html'], ["HELLO"]];
-        });
-        exit 0;
-    }
-
-    sleep 1;
-
-    kill 'TERM', $pid;
-    waitpid($pid, 0);
-};
+kill 'TERM', $pid;
+waitpid($pid, 0);
 
 done_testing();

--- a/t/14child_finish_hook.t
+++ b/t/14child_finish_hook.t
@@ -1,0 +1,60 @@
+use strict;
+use warnings;
+
+use Test::More;
+use Plack::Loader;
+use Plack::Runner;
+
+$SIG{CONT} = sub { pass('child_finish has been executed.') };
+
+subtest 'child_finish' => sub {
+    plan tests => 1;
+    my $main_pid = $$;
+    my $pid = fork;
+    if ( $pid == 0 ) {
+        my $loader = Plack::Loader->load(
+            'Starlet',
+            max_workers => 1,
+            child_finish  => sub { kill 'CONT', $main_pid },
+        );
+        $loader->run(sub{
+            my $env = shift;
+            [200, ['Content-Type'=>'text/html'], ["HELLO"]];
+        });
+        exit 0;
+    }
+
+    sleep 1;
+
+    kill 'TERM', $pid;
+    waitpid($pid, 0);
+};
+
+subtest 'hook_module' => sub {
+    plan tests => 1;
+    our $main_pid = $$;
+    my $pid = fork;
+    if ( $pid == 0 ) {
+        {
+            package ChildFinishHook;
+            sub child_finish_hook { kill 'CONT', $main_pid }
+        }
+        my $runner = Plack::Runner->new;
+        $runner->parse_options(
+            qw(--server Starlet --max-workers 1
+               --hook-module ChildFinishHook --child-finish-hook child_finish_hook)
+        );
+        $runner->run(sub{
+            my $env = shift;
+            [200, ['Content-Type'=>'text/html'], ["HELLO"]];
+        });
+        exit 0;
+    }
+
+    sleep 1;
+
+    kill 'TERM', $pid;
+    waitpid($pid, 0);
+};
+
+done_testing();


### PR DESCRIPTION
Hi @kazuho ,

I am going to execute some codes right before the child process exits. 
And I found that it might be possible to replace `Parallel::Prefork::finish` into a custom subroutine to achieve it.
https://github.com/kazuho/Starlet/blob/master/lib/Plack/Handler/Starlet.pm#L76

However, the child process would exit immediately and `Parallel::Prefork::finish` would never be called.
It might be good to let `Parallel::Prefork` handle process exit since it seems that it deals with everything about process manager.

Furthermore, it might be better and clearer to add a `child_finish_hook` to `Starlet::Server`; but for now, following changes are enough for me and it should not have any impact on other current codes.

Therefore, I would like to propose this pull request in order to let `Parallel::Prefork::finish` be called when the child process is about to exit.

Thanks.
