### PR TITLE
expose callback for sending an interim response

### DIFF
--- a/t/14interim_response.t
+++ b/t/14interim_response.t
@@ -1,0 +1,43 @@
+use strict;
+use warnings;
+use Test::More;
+use Test::TCP qw(test_tcp);
+use IO::Socket::INET;
+use Plack::Loader;
+
+test_tcp(
+    client => sub {
+        my $port = shift;
+        my $sock = IO::Socket::INET->new(
+            PeerAddr => "localhost:$port",
+            Proto => 'tcp',
+        );
+
+        my $req = "GET / HTTP/1.1\015\012\015\012";
+        $sock->syswrite($req, length $req);
+
+        my $resp = "";
+        while ($sock->sysread($resp, 65536, length $resp)) {}
+
+        my $expected_interim = <<"EOT";
+HTTP/1\.1 100 Continue\015
+foo: 123\015
+bar: 456\015
+\015
+EOT
+        is substr($resp, 0, length $expected_interim), $expected_interim;
+        like substr($resp, length $expected_interim), qr{^HTTP/1\.1 200 OK\015\012}is;
+    },
+    server => sub {
+        my $port = shift;
+        my $loader = Plack::Loader->load('Starlet', port => $port);
+        $loader->run(sub {
+            my $env = shift;
+            $env->{"psgix.informational"}->(100, [foo => 123, bar => 456]);
+            [200, ['Content-Type' => 'text/plain'], ["OK"]];
+        });
+        exit;
+    },
+);
+
+done_testing;


### PR DESCRIPTION
A subref is exported as `psgix.informational` for sending an interim response, defined in [RFC 7231 section 6.2](https://tools.ietf.org/html/rfc7231#section-6.2).

```
6.2.  Informational 1xx

   The 1xx (Informational) class of status code indicates an interim
   response for communicating connection status or request progress
   prior to completing the requested action and sending a final
   response.
```

The subref takes two arguments.  The first argument is the 1xx status code to be sent to the client.  The second argument is an reference to an array of headers that should be sent.  In other words, it is the same as the PSGI response but without a body.

The intended use-case of the extension is to to trigger HTTP/2 servers running downstream start pushing the specified resources (e.g. CSS, JavaScript) while the PSGI application generates a response.  By using the extension, PSGI applications can send a set of `link: rel=preload` headers associated to an 1xx response (which is recognized by the HTTP/2 servers as a signal to start pushing the assets), and then process the request.

see also: https://github.com/h2o/h2o/issues/672#issuecomment-218410576