### PR TITLE
should call srand without arguments

### DIFF
--- a/lib/Plack/Handler/Starlet.pm
+++ b/lib/Plack/Handler/Starlet.pm
@@ -76,7 +76,7 @@ sub run {
         my $pm = Parallel::Prefork->new(\%pm_args);
         while ($pm->signal_received !~ /^(TERM|USR1)$/) {
             $pm->start and next;
-            srand((rand() * 2 ** 30) ^ $$ ^ time);
+            srand;
             $self->accept_loop($app, $self->_calc_reqs_per_child());
             $pm->finish;
         }


### PR DESCRIPTION
When The Perl5's srand function is called without arguments,
initialize random seed using `/dev/urandom`.

SEE ALSO:
https://perl5.git.perl.org/perl.git/blob?f=pp.c#l3047
https://perl5.git.perl.org/perl.git/blob?f=util.c#l4652